### PR TITLE
add storage module for retaining messages in kv store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,7 +125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -164,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -231,7 +237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9b3460f44bea8cd47f45a0c70892f1eff856d97cd55358b2f73f663789f6190"
 dependencies = [
  "ct-codecs",
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -255,7 +261,7 @@ dependencies = [
  "hkdf",
  "pem-rfc7468 0.7.0",
  "pkcs8 0.10.2",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -321,7 +327,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd73cda7d97b4abe3c3bee2bd78941157413037792c8a685cbcaacfa636380dc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "http",
 ]
 
@@ -331,7 +337,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8ee1f2773576f963b1841c825b569f1cb2a59a4dbff8348e1b72f22e6e01da3"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "fastly-shared",
 ]
 
@@ -341,7 +347,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -380,8 +386,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -391,7 +409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -651,7 +669,7 @@ dependencies = [
  "k256",
  "p256",
  "p384",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "serde_json",
@@ -731,7 +749,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -905,9 +923,11 @@ dependencies = [
  "fastly",
  "hex",
  "jwt-simple",
+ "rand 0.9.1",
  "serde",
  "serde_json",
  "sha1",
+ "time",
 ]
 
 [[package]]
@@ -920,14 +940,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -937,7 +973,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -946,7 +992,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -973,7 +1028,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8 0.9.0",
- "rand_core",
+ "rand_core 0.6.4",
  "signature 1.6.4",
  "smallvec",
  "subtle",
@@ -1086,7 +1141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1096,7 +1151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1198,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "num-conv",
@@ -1212,15 +1267,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1284,12 +1339,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasix"
 version = "0.12.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fbb4ef9bbca0c1170e0b00dd28abc9e3b68669821600cad1caaed606583c6d"
 dependencies = [
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1346,6 +1410,15 @@ name = "wasm-bindgen-shared"
 version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.0",
+]
 
 [[package]]
 name = "write16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,11 @@ base64 = "0.22"
 fastly = "0.11"
 hex = "0.4"
 jwt-simple = "0.11"
+rand = "0.9"
 serde = "1"
 serde_json = "1"
 sha1 = "0.10"
+time = "0.3"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(viceroy)'] }

--- a/example_keys.json
+++ b/example_keys.json
@@ -1,0 +1,3 @@
+{
+  "test": "notasecret"
+}

--- a/example_messages.json
+++ b/example_messages.json
@@ -1,0 +1,6 @@
+{
+  "r:test": {
+    "metadata": "{\"version\": 1}",
+    "data": "saved message"
+  }
+}

--- a/fastly.toml
+++ b/fastly.toml
@@ -32,3 +32,9 @@ name = "Pub/Sub"
 
     [setup.secret_stores.secrets]
       description = "Store for secret configuration values"
+
+[local_server]
+
+  [local_server.kv_stores]
+    keys = { file = "example_keys.json", format = "json" }
+    messages = { file = "example_messages.json", format = "json" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,5 @@ pub mod mqttpacket;
 pub mod mqtttransport;
 pub mod publish;
 pub mod routes;
+pub mod storage;
 pub mod websocket;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,248 @@
+use fastly::kv_store::{InsertMode, KVStoreError, LookupResponse};
+use fastly::KVStore;
+use std::time::Duration;
+
+const KV_STORE_MAX_AGE_SECS: u64 = 60 * 60;
+const TTL_EXTEND: Duration =
+    Duration::from_secs(KV_STORE_MAX_AGE_SECS + (KV_STORE_MAX_AGE_SECS / 2));
+const WRITE_TRIES_MAX: usize = 5;
+
+#[derive(Debug)]
+pub enum StorageError {
+    StoreNotFound,
+    TooManyRequests,
+    InvalidMetadata,
+    KVStore(KVStoreError),
+}
+
+pub struct RetainedVersion {
+    pub generation: u64,
+    pub seq: u64,
+}
+
+pub struct Retained {
+    pub version: RetainedVersion,
+    pub ttl: Option<Duration>,
+    pub message: Vec<u8>,
+}
+
+#[derive(Debug, Default, serde::Deserialize, serde::Serialize)]
+struct Metadata {
+    generation: u64,
+    seq: u64,
+
+    #[serde(rename = "expires-at", skip_serializing_if = "Option::is_none")]
+    expires_at: Option<time::UtcDateTime>,
+}
+
+fn lookup(
+    store: &KVStore,
+    key_name: &str,
+) -> Result<Option<(LookupResponse, Metadata)>, StorageError> {
+    let lookup = match store.lookup(key_name) {
+        Ok(l) => l,
+        Err(KVStoreError::ItemNotFound) => return Ok(None),
+        Err(e) => return Err(StorageError::KVStore(e)),
+    };
+
+    let meta = match lookup.metadata() {
+        Some(data) => match serde_json::from_slice(&data) {
+            Ok(v) => v,
+            Err(_) => return Err(StorageError::InvalidMetadata),
+        },
+        None => return Err(StorageError::InvalidMetadata),
+    };
+
+    Ok(Some((lookup, meta)))
+}
+
+pub trait Storage {
+    fn write_retained(
+        &self,
+        topic: &str,
+        message: &[u8],
+        ttl: Option<Duration>,
+    ) -> Result<RetainedVersion, StorageError>;
+
+    fn read_retained(&self, topic: &str) -> Result<Option<Retained>, StorageError>;
+}
+
+pub struct KVStoreStorage {
+    store_name: String,
+}
+
+impl KVStoreStorage {
+    pub fn new(store_name: &str) -> Self {
+        Self {
+            store_name: store_name.to_string(),
+        }
+    }
+}
+
+impl Storage for KVStoreStorage {
+    fn write_retained(
+        &self,
+        topic: &str,
+        message: &[u8],
+        ttl: Option<Duration>,
+    ) -> Result<RetainedVersion, StorageError> {
+        let store = match KVStore::open(&self.store_name) {
+            Ok(Some(store)) => store,
+            Ok(None) => return Err(StorageError::StoreNotFound),
+            Err(e) => return Err(StorageError::KVStore(e)),
+        };
+
+        let key_name = format!("r:{}", topic);
+
+        let expires_at = ttl.map(|ttl| time::UtcDateTime::now() + ttl);
+
+        let mut tries = 0;
+
+        let version = loop {
+            let (mut meta, generation) = match lookup(&store, &key_name)? {
+                Some((lookup, meta)) => (meta, Some(lookup.current_generation())),
+                None => (Metadata::default(), None),
+            };
+
+            let insert = store.build_insert();
+
+            let insert = if let Some(generation) = generation {
+                meta.seq += 1;
+
+                insert.if_generation_match(generation)
+            } else {
+                meta.generation = rand::random();
+                meta.seq = 1;
+
+                insert.mode(InsertMode::Add)
+            };
+
+            meta.expires_at = expires_at;
+
+            let meta_json =
+                serde_json::to_string(&meta).expect("metadata should always be serializable");
+
+            let insert = insert.metadata(&meta_json);
+
+            let insert = if let Some(ttl) = ttl {
+                insert.time_to_live(ttl + TTL_EXTEND)
+            } else {
+                insert
+            };
+
+            match insert.execute(&key_name, message.to_vec()) {
+                Ok(()) => {
+                    break RetainedVersion {
+                        generation: meta.generation,
+                        seq: meta.seq,
+                    }
+                }
+                Err(KVStoreError::ItemPreconditionFailed) => {}
+                Err(KVStoreError::TooManyRequests) => {}
+                Err(e) => return Err(StorageError::KVStore(e)),
+            }
+
+            tries += 1;
+
+            if tries >= WRITE_TRIES_MAX {
+                // getting conflicts or rate limit errors after several tries
+                return Err(StorageError::TooManyRequests);
+            }
+        };
+
+        Ok(version)
+    }
+
+    fn read_retained(&self, topic: &str) -> Result<Option<Retained>, StorageError> {
+        let store = match KVStore::open(&self.store_name) {
+            Ok(Some(store)) => store,
+            Ok(None) => return Err(StorageError::StoreNotFound),
+            Err(e) => return Err(StorageError::KVStore(e)),
+        };
+
+        let key_name = format!("r:{}", topic);
+
+        let (mut lookup, meta) = match lookup(&store, &key_name)? {
+            Some(ret) => ret,
+            None => return Ok(None),
+        };
+
+        let mut ttl = None;
+
+        if let Some(expires_at) = meta.expires_at {
+            let now = time::UtcDateTime::now();
+
+            if now >= expires_at {
+                // ignore the value until it gets cleaned up
+                return Ok(None);
+            }
+
+            ttl = Some((expires_at - now).unsigned_abs());
+        }
+
+        let value = lookup.take_body_bytes();
+
+        Ok(Some(Retained {
+            version: RetainedVersion {
+                generation: meta.generation,
+                seq: meta.seq,
+            },
+            ttl,
+            message: value,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str;
+
+    #[test]
+    fn retained() {
+        let storage = KVStoreStorage::new("messages");
+
+        assert!(storage.read_retained("storage-test").unwrap().is_none());
+
+        let v1 = storage
+            .write_retained("storage-test", "hello".as_bytes(), None)
+            .unwrap();
+        assert_eq!(v1.seq, 1);
+
+        let r = storage.read_retained("storage-test").unwrap().unwrap();
+        assert_eq!(r.version.generation, v1.generation);
+        assert_eq!(r.version.seq, 1);
+        assert!(r.ttl.is_none());
+        assert_eq!(str::from_utf8(&r.message).unwrap(), "hello");
+
+        let v2 = storage
+            .write_retained(
+                "storage-test",
+                "world".as_bytes(),
+                Some(Duration::from_secs(60)),
+            )
+            .unwrap();
+        assert_eq!(v2.generation, v1.generation);
+        assert_eq!(v2.seq, 2);
+
+        let r = storage.read_retained("storage-test").unwrap().unwrap();
+        assert_eq!(r.version.generation, v2.generation);
+        assert_eq!(r.version.seq, 2);
+        let ttl = r.ttl.unwrap();
+        assert!(ttl <= Duration::from_secs(60));
+        assert_eq!(str::from_utf8(&r.message).unwrap(), "world");
+
+        // delete item so next write gets a new generation
+        KVStore::open(&storage.store_name)
+            .unwrap()
+            .unwrap()
+            .delete("r:storage-test")
+            .unwrap();
+
+        let new_v1 = storage
+            .write_retained("storage-test", "hello".as_bytes(), None)
+            .unwrap();
+        assert!(new_v1.generation != v1.generation);
+        assert_eq!(new_v1.seq, 1);
+    }
+}


### PR DESCRIPTION
As a first step towards implementing message durability, this PR adds a module, `storage`, that allows saving a single message per topic. It contains a `Storage` trait and a KV Store based implementation.

The module is not used anywhere yet, but the plan is to use it to:

* Implement retained message support in the MQTT handler, by saving messages when publishing, and replaying them when subscribing.
* Implement saving/replaying in the HTTP handler, by saving messages when POST'ing, and replaying them when SSE subscribing.

KV item metadata is used to keep a version and an optional expiration time. The version consists of a generation number (randomly generated) and a sequence number (strictly increasing); these values will be needed to implement ordered & reliable message delivery. The expiration time maintained in the metadata allows us to treat the item's content as expired even if the item itself persists. This is mainly useful for when a topic's message expires and is later replaced by a new message, we can reuse the generation/sequence.

Writing to KV Store is limited to 1 write/second per key. This module attempts to work around this slightly, by retrying a few times if a write fails. This way, serial writes to the same topic from a single writer should not encounter write-rate errors and instead may experience a backpressure effect. However, multiple writes in parallel to the same topic could result in errors due to the write-rate.