### PR TITLE
add more mqtt packet fields

### DIFF
--- a/src/mqtttransport.rs
+++ b/src/mqtttransport.rs
@@ -267,6 +267,7 @@ mod tests {
         let p = Publish {
             topic: Cow::from("fruit"),
             message: Cow::from("apple".as_bytes()),
+            retain: false,
         };
 
         let mut packet_bytes = Vec::new();
@@ -289,6 +290,7 @@ mod tests {
                     out = Some(Publish {
                         topic: Cow::from(p.topic.clone().into_owned()),
                         message: Cow::from(p.message.clone().into_owned()),
+                        retain: false,
                     });
                 }
 
@@ -313,6 +315,7 @@ mod tests {
                     out = Some(Publish {
                         topic: Cow::from(p.topic.clone().into_owned()),
                         message: Cow::from(p.message.clone().into_owned()),
+                        retain: false,
                     });
                 }
 

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -44,6 +44,7 @@ pub fn publish(api_token: &str, topic: &str, message: &[u8]) -> Result<(), Error
         Packet::Publish(Publish {
             topic: Cow::from(topic),
             message: Cow::from(message),
+            retain: false,
         })
         .serialize(&mut v)?;
 


### PR DESCRIPTION
Notably, this includes fields related to retained messages, which we'll use when implementing durability.