### PR TITLE
mqtt: add support for retained messages stored in KV store

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -171,7 +171,7 @@ pub fn post(config: &Config, authorizor: &dyn Authorizor, mut req: Request) -> R
         );
     }
 
-    if publish(&config.publish_token, topic, &message, None).is_err() {
+    if publish(&config.publish_token, topic, &message, None, None).is_err() {
         return text_response(StatusCode::INTERNAL_SERVER_ERROR, "Publish process failed");
     }
 

--- a/src/mqtthandler.rs
+++ b/src/mqtthandler.rs
@@ -4,18 +4,49 @@ use crate::mqttpacket::{
     ConnAck, ConnAckV4, Connect, Disconnect, Packet, PingReq, PingResp, Publish, Reason, SubAck,
     Subscribe, UnsubAck, Unsubscribe,
 };
-use crate::publish::{publish, MESSAGE_SIZE_MAX};
-use crate::storage::Storage;
+use crate::publish::{publish, Sequencing, MESSAGE_SIZE_MAX};
+use crate::storage::{RetainedVersion, Storage, StorageError};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::ops::Not;
+use std::time::Duration;
 
 const PACKET_SIZE_MAX: usize = 32_768;
+
+#[derive(Deserialize, Serialize, Default)]
+pub struct Version {
+    #[serde(rename = "g")]
+    pub generation: u64,
+
+    #[serde(rename = "s")]
+    pub seq: u64,
+}
+
+impl Version {
+    pub fn to_id(&self) -> String {
+        format!("{}-{}", self.generation, self.seq)
+    }
+}
+
+#[derive(Deserialize, Serialize, Default)]
+pub struct Last {
+    #[serde(rename = "v", skip_serializing_if = "Option::is_none")]
+    pub version: Option<Version>,
+}
 
 #[derive(Deserialize, Serialize, Default)]
 pub struct Subscription {
     #[serde(rename = "nl", skip_serializing_if = "<&bool>::not", default)]
     pub no_local: bool,
+
+    #[serde(rename = "rap", skip_serializing_if = "<&bool>::not", default)]
+    pub retain_as_published: bool,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last: Option<Last>,
+
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub ignore: Vec<Version>,
 }
 
 #[derive(Deserialize, Serialize, Default)]
@@ -124,17 +155,56 @@ fn handle_subscribe<'a>(ctx: &mut Context, p: Subscribe<'a>) -> Vec<Packet<'a>> 
         })];
     }
 
+    let mut retained = None;
+
+    match ctx.storage.read_retained(p.topic, None) {
+        Ok(Some(r)) => retained = Some(r),
+        Ok(None) | Err(StorageError::StoreNotFound) => {}
+        Err(_) => {
+            return vec![Packet::SubAck(SubAck {
+                id: p.id,
+                reason: Reason::UnspecifiedError,
+            })]
+        }
+    }
+
+    let version = retained.as_ref().map(|r| Version {
+        generation: r.version.generation,
+        seq: r.version.seq,
+    });
+
     ctx.state.subs.insert(
         p.topic.to_string(),
         Subscription {
             no_local: p.no_local,
+            retain_as_published: p.retain_as_published,
+            last: Some(Last { version }),
+            ignore: Vec::new(),
         },
     );
 
-    vec![Packet::SubAck(SubAck {
+    let mut out = vec![Packet::SubAck(SubAck {
         id: p.id,
         reason: Reason::Success,
-    })]
+    })];
+
+    // 0 means send upon new subscription
+    if p.retain_handling == 0 {
+        if let Some(r) = retained {
+            if let Some(message) = r.message {
+                out.push(Packet::Publish(Publish {
+                    topic: p.topic.into(),
+                    message: message.data.into(),
+                    dup: false,
+                    qos: 0,
+                    retain: true,
+                    message_expiry_interval: message.ttl.map(|d| d.as_secs() as u32),
+                }));
+            }
+        }
+    }
+
+    out
 }
 
 fn handle_unsubscribe<'a>(ctx: &mut Context, p: Unsubscribe<'a>) -> Vec<Packet<'a>> {
@@ -182,6 +252,48 @@ fn handle_publish<'a>(ctx: &mut Context, p: Publish<'a>) -> Vec<Packet<'a>> {
 
     let mut out = vec![];
 
+    let mut version = None;
+
+    if p.retain {
+        let ttl = p
+            .message_expiry_interval
+            .map(|x| Duration::from_secs(x.into()));
+
+        match ctx.storage.write_retained(&p.topic, &p.message, ttl) {
+            Ok(v) => version = Some(v),
+            Err(e) => {
+                // no error response. only log
+                println!("failed to write message to storage: {:?}", e);
+            }
+        }
+    }
+
+    let seq = version.map(|v| {
+        let version = Version {
+            generation: v.generation,
+            seq: v.seq,
+        };
+
+        let prev_id = if v.seq > 1 {
+            // if we wrote version 2 or later, it implies the slot
+            // existed and thus the previous write would have been
+            // for the same generation
+            Version {
+                generation: v.generation,
+                seq: v.seq - 1,
+            }
+            .to_id()
+        } else {
+            // if we wrote version 1, it implies the slot was empty
+            "none".to_string()
+        };
+
+        Sequencing {
+            id: version.to_id(),
+            prev_id,
+        }
+    });
+
     let ignore = match ctx.state.subs.get(&*p.topic) {
         Some(sub) => sub.no_local,
         None => false,
@@ -192,20 +304,21 @@ fn handle_publish<'a>(ctx: &mut Context, p: Publish<'a>) -> Vec<Packet<'a>> {
             &ctx.config.publish_token,
             &p.topic,
             &p.message,
+            seq,
             Some(&ctx.state.client_id),
         ) {
             // no error response. only log
             println!("failed to publish: {:?}", e);
         }
-    } else if !ignore {
+    } else if seq.is_none() && !ignore {
         println!("publishing not configured, echoing back to sender");
         out.push(Packet::Publish(Publish {
             topic: p.topic,
             message: p.message,
             dup: false,
             qos: 0,
-            retain: false,
-            message_expiry_interval: None,
+            retain: false,                 // always false for non-durable
+            message_expiry_interval: None, // always none for non-durable
         }));
     }
 
@@ -226,6 +339,66 @@ pub fn handle_packet<'a>(ctx: &mut Context, p: Packet<'a>) -> Vec<Packet<'a>> {
             println!("skipping unsupported packet type {}", ptype)
         }
         _ => println!("skipping unexpected packet"),
+    }
+
+    out
+}
+
+pub fn handle_sync(ctx: &mut Context) -> Vec<Packet<'static>> {
+    let mut out = Vec::new();
+
+    for (topic, sub) in &mut ctx.state.subs {
+        let Some(last) = &mut sub.last else {
+            continue;
+        };
+
+        let after = last.version.as_ref().map(|v| RetainedVersion {
+            generation: v.generation,
+            seq: v.seq,
+        });
+
+        let r = match ctx.storage.read_retained(topic, after) {
+            Ok(Some(r)) => r,
+            Ok(None) => continue,
+            Err(_) => {
+                out.push(Packet::Disconnect(Disconnect {
+                    reason: Reason::UnspecifiedError,
+                }));
+
+                ctx.disconnect = true;
+
+                break;
+            }
+        };
+
+        last.version = Some(Version {
+            generation: r.version.generation,
+            seq: r.version.seq,
+        });
+
+        let mut ignore = false;
+
+        sub.ignore.retain(|i| {
+            if r.version.generation == i.generation && r.version.seq == i.seq {
+                ignore = true;
+            }
+
+            // keep later ignored versions
+            i.generation == r.version.generation && i.seq > r.version.seq
+        });
+
+        if let Some(message) = r.message {
+            if !ignore {
+                out.push(Packet::Publish(Publish {
+                    topic: topic.to_string().into(),
+                    message: message.data.into(),
+                    dup: false,
+                    qos: 0,
+                    retain: sub.retain_as_published,
+                    message_expiry_interval: message.ttl.map(|d| d.as_secs() as u32),
+                }));
+            }
+        }
     }
 
     out


### PR DESCRIPTION
This adds optional message durability by saving messages in KV Store. Up to 1 message may be saved per topic, to be replayed when subscriptions are established. At first this is only supported via MQTT, using the "retained messages" protocol feature.

While only being able to save 1 message per topic may seem limiting, this limitation makes it practical to save messages for a long time or indefinitely, enabling behavior that is harder to misuse than with a typical time-limited queue. There is also no worry about clients receiving a deluge of messages when reconnecting after being disconnected for a long time, as only the most recent message is replayed.

Last mile pub/sub use-cases typically fall into two groups:

1. Only the last value is needed (e.g. sports scores). In this case, interim messages are usually not interesting and having only the last value is fine.
2. All values are needed (e.g. chat). In this case, when using a conventional time-limited queue, it's easy to forget that an out-of-band retrieval mechanism will be needed for when messages expire. We "solve" this by simply not storing a queue at all and obligating the developer to build an out-of-band retrieval mechanism for correctness from the start. The pub/sub topic can then be used for signaling only, e.g. last chat message ID/timestamp.

Notes:

* Fanout's WebSocket transport doesn't support reliable delivery, so instead we fake it by keeping last known message versions in session state and publish refresh actions. Upon refresh, messages are fetched from KV Store.
* Sequence IDs are passed to the `publish` function for durable messages. For now we don't use their actual values (only their presence, to know when to use a refresh action), but we will use them later when we add retained message support for SSE.
* Only messages published and consumed via MQTT can use this ability. Messages published via HTTP POST are not retained, and messages published via MQTT with the retain flag are not replayed to SSE subscribers.