### PR TITLE
mqtttransport: make subprotocol optional and set client id in meta

### DIFF
--- a/src/mqtthandler.rs
+++ b/src/mqtthandler.rs
@@ -14,6 +14,7 @@ const PACKET_SIZE_MAX: usize = 32_768;
 #[derive(Deserialize, Serialize, Default)]
 pub struct State {
     pub connected: bool,
+    pub client_id: String,
     pub token: Option<String>,
     pub subs: HashSet<String>,
 }
@@ -21,6 +22,7 @@ pub struct State {
 impl State {
     fn clear(&mut self) {
         self.connected = false;
+        self.client_id.clear();
         self.token = None;
         self.subs.clear();
     }
@@ -60,6 +62,7 @@ fn handle_connect<'a>(ctx: &mut Context, p: Connect<'a>) -> Vec<Packet<'a>> {
     // mark the session as connected and stash the token
 
     ctx.state.connected = true;
+    ctx.state.client_id = p.client_id.to_string();
 
     if let Some(s) = p.password {
         ctx.state.token = Some(s.to_string());

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -13,6 +13,15 @@ pub struct ControlMessage {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub channel: Option<String>,
+
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub filters: Vec<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
 }
 
 fn find_byte(haystack: &[u8], needle: u8) -> Option<usize> {


### PR DESCRIPTION
This makes it so we only set `Sec-WebSocket-Protocol` in the handshake response if the client asks for it, to avoid confusing clients. Also, set the client-asserted ID as metadata on the session, which we'll use later to implement the "No Local" protocol feature.