### PR TITLE
mqtt: add support for "no local"

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -171,7 +171,7 @@ pub fn post(config: &Config, authorizor: &dyn Authorizor, mut req: Request) -> R
         );
     }
 
-    if publish(&config.publish_token, topic, &message).is_err() {
+    if publish(&config.publish_token, topic, &message, None).is_err() {
         return text_response(StatusCode::INTERNAL_SERVER_ERROR, "Publish process failed");
     }
 


### PR DESCRIPTION
This lets subscribers indicate that they don't want to receive their own published messages. I thought I'd reason through this one at the same time as durability to ensure feasibility.

For non-durable messages it's fairly straightforward: we can use the `skip-self` Fanout filter to cause messages to be dropped if they include a `sender` meta value equal to the client ID (this works because we set a `user` meta value on the subscription to the client ID), and so that's what this PR does. It also establishes a `Subscription` state object, initially containing only a `no_local` flag which is used for filtering when running on viceroy.

For durable messages, the plan is to store recently published message versions in the `Subscription` object and then publish a refresh action to fetch, in which case we can do the filtering in the app itself upon refresh.