### PR TITLE
allow messages sent via http to be retained

### DIFF
--- a/src/routes.rs
+++ b/src/routes.rs
@@ -57,7 +57,7 @@ pub fn handle_request(
 
             events::get(authorizor, req)
         } else if req.get_method() == Method::POST && config.http_publish_enabled {
-            events::post(&config, authorizor, req)
+            events::post(&config, authorizor, storage, req)
         } else {
             let mut allow = "OPTIONS".to_string();
 


### PR DESCRIPTION
This allows publishing durably via POST, to be received durably by MQTT subscribers. SSE subscribers still only receive non-durably.

The sequencing code is duplicated from `mqtthandler`. Will look at consolidating that after implementing durability for SSE.