### PR TITLE
add durable sse subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
  "serde_urlencoded",
  "sha2 0.9.9",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "url",
 ]
@@ -674,7 +674,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spki 0.6.0",
- "thiserror",
+ "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -927,6 +927,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
+ "thiserror 2.0.12",
  "time",
 ]
 
@@ -1237,7 +1238,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1245,6 +1255,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rand = "0.9"
 serde = "1"
 serde_json = "1"
 sha1 = "0.10"
+thiserror = "2"
 time = "0.3"
 
 [lints.rust]

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -16,8 +16,8 @@ fn text_response(status: StatusCode, text: &str) -> Response {
     Response::from_status(status).with_body_text_plain(&format!("{text}\n"))
 }
 
-pub fn post_keys(req: Request) -> Response {
-    if !req.fastly_key_is_valid() {
+pub fn post_keys(fastly_authed: bool, _req: Request) -> Response {
+    if !fastly_authed {
         return text_response(
             StatusCode::UNAUTHORIZED,
             "Fastly-Key header invalid or not specified",

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ pub struct Config {
     pub mqtt_enabled: bool,
     pub admin_enabled: bool,
     pub publish_token: String,
+    pub internal_key: Vec<u8>,
 }
 
 impl Default for Config {
@@ -17,6 +18,7 @@ impl Default for Config {
             mqtt_enabled: true,
             admin_enabled: true,
             publish_token: String::new(),
+            internal_key: Vec::new(),
         }
     }
 }
@@ -98,6 +100,12 @@ impl Source for ConfigAndSecretStoreSource {
 
                     config.publish_token = v;
                 }
+                Ok(None) => {}
+                Err(_) => return Err(ConfigError::StoreError),
+            }
+
+            match store.try_get("internal-key") {
+                Ok(Some(v)) => config.internal_key = v.plaintext().to_vec(),
                 Ok(None) => {}
                 Err(_) => return Err(ConfigError::StoreError),
             }

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,15 +1,21 @@
-use crate::auth::{AuthorizationError, Authorizor, Capabilities};
+use crate::auth::{create_token, AuthorizationError, Authorizor, Capabilities};
 use crate::config::Config;
 use crate::publish::{publish, Sequencing, MESSAGE_SIZE_MAX};
-use crate::storage::Storage;
+use crate::storage::{RetainedVersion, Storage, StorageError};
+use base64::Engine;
 use fastly::http::{header, StatusCode};
 use fastly::{Request, Response};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+use std::fmt::Write;
 use std::str;
 use std::time::Duration;
+use thiserror::Error;
 
 const TOPICS_PER_REQUEST_MAX: usize = 10;
 
+struct VersionParseError;
+
+#[derive(Debug, Copy, Clone)]
 struct Version {
     generation: u64,
     seq: u64,
@@ -17,8 +23,68 @@ struct Version {
 
 impl Version {
     fn to_id(&self) -> String {
-        format!("{}-{}", self.generation, self.seq)
+        format!("{:16x}-{}", self.generation, self.seq)
     }
+
+    fn parse(s: &str) -> Result<Self, VersionParseError> {
+        let pos = match s.find('-') {
+            Some(pos) => pos,
+            None => return Err(VersionParseError),
+        };
+
+        let generation = &s[..pos];
+        let seq = &s[(pos + 1)..];
+
+        let Ok(generation) = u64::from_str_radix(generation, 16) else {
+            return Err(VersionParseError);
+        };
+
+        let Ok(seq) = seq.parse() else {
+            return Err(VersionParseError);
+        };
+
+        Ok(Self { generation, seq })
+    }
+}
+
+#[derive(Error, Debug)]
+enum GripLastError<'a> {
+    #[error("failed to parse grip last header: [{0}]")]
+    ParseHeader(&'a str),
+}
+
+// if there is at least one Grip-Last header, this function is guaranteed
+// to return at least one item or error
+fn parse_grip_last(req: &Request) -> Result<Vec<(&str, &str)>, GripLastError> {
+    let mut out = Vec::new();
+
+    for hvalue in req.get_header_all_str("Grip-Last") {
+        for value in hvalue.split(',') {
+            let Some(pos) = value.find(';') else {
+                return Err(GripLastError::ParseHeader(hvalue));
+            };
+
+            let channel = value[..pos].trim();
+            let params = &value[(pos + 1)..];
+
+            let Some(pos) = params.find("last-id=") else {
+                return Err(GripLastError::ParseHeader(hvalue));
+            };
+
+            let remainder = &params[(pos + 8)..];
+
+            let end = match remainder.find(';') {
+                Some(pos) => pos,
+                None => remainder.len(),
+            };
+
+            let id = remainder[..end].trim();
+
+            out.push((channel, id));
+        }
+    }
+
+    Ok(out)
 }
 
 fn text_response(status: StatusCode, text: &str) -> Response {
@@ -33,34 +99,123 @@ fn sse_error(condition: &str, text: &str) -> Response {
 
     let data = serde_json::to_string(&data).unwrap();
 
-    Response::from_status(StatusCode::OK)
+    Response::new()
         .with_header(header::CONTENT_TYPE, "text/event-stream")
         .with_body(format!("event: stream-error\ndata: {data}\n\n"))
 }
 
-pub fn get(authorizor: &dyn Authorizor, req: Request) -> Response {
-    let topics = {
-        let mut topics = HashSet::new();
+pub fn get(
+    config: &Config,
+    authorizor: &dyn Authorizor,
+    storage: &dyn Storage,
+    fastly_authed: bool,
+    req: Request,
+) -> Response {
+    let grip_last = match parse_grip_last(&req) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{e}");
 
+            // close
+            return Response::new();
+        }
+    };
+
+    let is_next = !grip_last.is_empty();
+
+    let mut topics = HashMap::new();
+
+    if !grip_last.is_empty() {
+        for &(channel, last_id) in &grip_last {
+            if !channel.starts_with("d:") {
+                continue;
+            }
+
+            let topic = &channel[2..];
+
+            let version = if last_id != "none" {
+                let Ok(version) = Version::parse(last_id) else {
+                    println!("grip last ID not a valid version: [last_id]");
+
+                    // close
+                    return Response::new();
+                };
+
+                Some(version)
+            } else {
+                None
+            };
+
+            topics.insert(topic.to_string(), version);
+        }
+
+        if topics.is_empty() {
+            println!("no valid grip last topics");
+
+            // close
+            return Response::new();
+        }
+    } else {
         for (k, v) in req.get_url().query_pairs() {
             if k == "topic" {
-                topics.insert(v.to_string());
+                topics.insert(v.to_string(), None);
             }
         }
 
-        topics
-    };
-
-    if topics.is_empty() {
-        return sse_error("bad-request", "Missing 'topic' parameter");
+        if topics.is_empty() {
+            return sse_error("bad-request", "Missing 'topic' parameter");
+        }
     }
 
     if topics.len() >= TOPICS_PER_REQUEST_MAX {
         return sse_error("bad-request", "Too many topics");
     }
 
-    let caps = if req.fastly_key_is_valid() {
-        Capabilities::new_admin()
+    if grip_last.is_empty() {
+        let last_event_id = if let Some(s) = req.get_query_parameter("lastEventId") {
+            Some(s)
+        } else if let Some(s) = req.get_header_str("Last-Event-ID") {
+            Some(s)
+        } else {
+            None
+        };
+
+        if let Some(last_event_id) = last_event_id {
+            for part in last_event_id.split(',') {
+                let Some(pos) = part.find(':') else {
+                    return sse_error("bad-request", "Last-Event-ID part missing ':'\n");
+                };
+
+                let topic = &part[..pos];
+                let version = &part[(pos + 1)..];
+
+                let Ok(version) = Version::parse(version) else {
+                    return sse_error(
+                        "bad-request",
+                        &format!("Last-Event-ID part not a valid version: [{}]\n", version),
+                    );
+                };
+
+                if let Some(v) = topics.get_mut(topic) {
+                    *v = Some(version);
+                }
+            }
+        }
+    }
+
+    let durable = req.get_query_parameter("durable") == Some("true");
+
+    let (token, caps) = if fastly_authed {
+        let readable_topics = topics.keys().cloned().collect();
+
+        let token = create_token(
+            readable_topics,
+            Vec::new(),
+            "internal",
+            &config.internal_key,
+        );
+
+        (token, Capabilities::new_admin())
     } else {
         let token = if let Some(v) = req.get_query_parameter("auth") {
             v
@@ -88,7 +243,7 @@ pub fn get(authorizor: &dyn Authorizor, req: Request) -> Response {
             );
         };
 
-        match authorizor.validate_token(token) {
+        let caps = match authorizor.validate_token(token, Some(&config.internal_key)) {
             Ok(caps) => caps,
             Err(AuthorizationError::Token(_)) => {
                 return sse_error("forbidden", "Invalid token");
@@ -98,16 +253,103 @@ pub fn get(authorizor: &dyn Authorizor, req: Request) -> Response {
 
                 return sse_error("internal-server-error", "Auth process failed");
             }
-        }
+        };
+
+        (token.to_string(), caps)
     };
 
-    for topic in &topics {
+    for topic in topics.keys() {
         if !caps.can_subscribe(topic) {
             return sse_error("forbidden", &format!("Cannot subscribe to topic: {topic}"));
         }
     }
 
-    let mut resp = Response::from_status(StatusCode::OK)
+    let mut events = Vec::new();
+
+    if durable {
+        let mut keys: Vec<String> = topics.keys().cloned().collect();
+        keys.sort();
+
+        for topic in &keys {
+            let version = topics.get_mut(topic).unwrap();
+
+            let after = version.map(|v| RetainedVersion {
+                generation: v.generation,
+                seq: v.seq,
+            });
+
+            let retained = match storage.read_retained(topic, after) {
+                Ok(Some(r)) => r,
+                Ok(None) | Err(StorageError::StoreNotFound) => continue,
+                Err(e) => {
+                    println!("failed to read message from storage: {:?}", e);
+
+                    return sse_error(
+                        "internal-server-error",
+                        "Failed to read message from storage",
+                    );
+                }
+            };
+
+            let v = Version {
+                generation: retained.version.generation,
+                seq: retained.version.seq,
+            };
+
+            *version = Some(v);
+
+            let Some(message) = retained.message else {
+                continue;
+            };
+
+            let id = {
+                let mut parts = Vec::new();
+
+                for topic in &keys {
+                    if let Some(v) = &topics[topic] {
+                        let id = v.to_id();
+                        parts.push(format!("{topic}:{id}"));
+                    }
+                }
+
+                parts.join(",")
+            };
+
+            let sse_content = match str::from_utf8(&message.data) {
+                Ok(s) => {
+                    let mut content = String::new();
+                    content.push_str("event: message\n");
+                    content.write_fmt(format_args!("id: {id}\n")).unwrap();
+
+                    for line in s.split('\n') {
+                        content.write_fmt(format_args!("data: {line}\n")).unwrap();
+                    }
+
+                    content.push('\n');
+
+                    content
+                }
+                Err(_) => {
+                    let encoded = base64::prelude::BASE64_STANDARD.encode(message.data);
+
+                    let mut content = String::new();
+                    content.push_str("event: message-base64\n");
+                    content.write_fmt(format_args!("id: {id}\n")).unwrap();
+                    content.push_str("data: ");
+                    content.push_str(&encoded);
+                    content.push_str("\n\n");
+
+                    content
+                }
+            };
+
+            events.push(sse_content);
+        }
+    }
+
+    println!("topics: {:?}", topics);
+
+    let mut resp = Response::new()
         .with_header(header::CONTENT_TYPE, "text/event-stream")
         .with_header("Grip-Hold", "stream")
         .with_header(
@@ -115,17 +357,44 @@ pub fn get(authorizor: &dyn Authorizor, req: Request) -> Response {
             "event: keep-alive\\ndata: \\n\\n; format=cstring; timeout=55",
         );
 
-    for topic in topics {
+    for (topic, version) in &topics {
         resp.append_header("Grip-Channel", format!("s:{topic}"));
+
+        if durable {
+            let prev_id = match version {
+                Some(v) => v.to_id(),
+                None => "none".to_string(),
+            };
+
+            resp.append_header("Grip-Channel", format!("d:{topic}; prev-id={prev_id}"));
+        }
     }
 
-    resp.with_body("event: stream-open\ndata: \n\n")
+    if durable {
+        resp.append_header(
+            "Grip-Link",
+            &format!("</events?durable=true&auth={token}>; rel=next; timeout=10"),
+        );
+    }
+
+    let mut body = String::new();
+
+    if !is_next {
+        body.push_str("event: stream-open\ndata: \n\n");
+    }
+
+    for s in events {
+        body.push_str(&s);
+    }
+
+    resp.with_body(body)
 }
 
 pub fn post(
     config: &Config,
     authorizor: &dyn Authorizor,
     storage: &dyn Storage,
+    fastly_authed: bool,
     mut req: Request,
 ) -> Response {
     let body = req.take_body();
@@ -149,7 +418,7 @@ pub fn post(
         None => None,
     };
 
-    let caps = if req.fastly_key_is_valid() {
+    let caps = if fastly_authed {
         Capabilities::new_admin()
     } else {
         let token = if let Some(v) = req.get_header_str(header::AUTHORIZATION) {
@@ -175,7 +444,7 @@ pub fn post(
             return text_response(StatusCode::BAD_REQUEST, "Missing 'Authorization' header");
         };
 
-        match authorizor.validate_token(token) {
+        match authorizor.validate_token(token, None) {
             Ok(caps) => caps,
             Err(AuthorizationError::Token(_)) => {
                 return text_response(StatusCode::FORBIDDEN, "Invalid token");

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,11 +13,12 @@ fn main() -> Result<(), Error> {
     if local {
         let config_source = config::TestSource;
 
-        routes::handle_request(&config_source, &authorizor, &storage, req)?;
+        routes::handle_request(&config_source, &authorizor, &storage, false, req)?;
     } else {
         let config_source = config::ConfigAndSecretStoreSource::new("config", "secrets");
+        let fastly_authed = req.fastly_key_is_valid();
 
-        routes::handle_request(&config_source, &authorizor, &storage, req)?;
+        routes::handle_request(&config_source, &authorizor, &storage, fastly_authed, req)?;
     }
 
     Ok(())

--- a/src/mqtthandler.rs
+++ b/src/mqtthandler.rs
@@ -24,7 +24,7 @@ pub struct Version {
 
 impl Version {
     pub fn to_id(&self) -> String {
-        format!("{}-{}", self.generation, self.seq)
+        format!("{:16x}-{}", self.generation, self.seq)
     }
 }
 
@@ -141,7 +141,7 @@ fn handle_subscribe<'a>(ctx: &mut Context, p: Subscribe<'a>) -> Vec<Packet<'a>> 
     let mut allowed = false;
 
     if let Some(s) = &ctx.state.token {
-        if let Ok(caps) = ctx.authorizor.validate_token(s) {
+        if let Ok(caps) = ctx.authorizor.validate_token(s, None) {
             if caps.can_subscribe(p.topic) {
                 allowed = true;
             }
@@ -241,7 +241,7 @@ fn handle_publish<'a>(ctx: &mut Context, p: Publish<'a>) -> Vec<Packet<'a>> {
     let mut allowed = false;
 
     if let Some(s) = &ctx.state.token {
-        if let Ok(caps) = ctx.authorizor.validate_token(s) {
+        if let Ok(caps) = ctx.authorizor.validate_token(s, None) {
             if caps.can_publish(p.topic.as_ref()) {
                 allowed = true;
             }

--- a/src/mqtttransport.rs
+++ b/src/mqtttransport.rs
@@ -240,6 +240,12 @@ where
                 filters,
                 ..Default::default()
             });
+
+            cmsgs.push(ControlMessage {
+                ctype: "subscribe".to_string(),
+                channel: Some(format!("d:{topic}")),
+                ..Default::default()
+            });
         }
     }
 
@@ -248,6 +254,12 @@ where
             cmsgs.push(ControlMessage {
                 ctype: "unsubscribe".to_string(),
                 channel: Some(format!("s:{topic}")),
+                ..Default::default()
+            });
+
+            cmsgs.push(ControlMessage {
+                ctype: "unsubscribe".to_string(),
+                channel: Some(format!("d:{topic}")),
                 ..Default::default()
             });
         }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -26,6 +26,7 @@ pub fn handle_request(
     config_source: &dyn config::Source,
     authorizor: &dyn auth::Authorizor,
     storage: &dyn storage::Storage,
+    fastly_authed: bool,
     req: Request,
 ) -> Result<(), Error> {
     let config = match config_source.config() {
@@ -55,9 +56,9 @@ pub fn handle_request(
                 return Ok(());
             }
 
-            events::get(authorizor, req)
+            events::get(&config, authorizor, storage, fastly_authed, req)
         } else if req.get_method() == Method::POST && config.http_publish_enabled {
-            events::post(&config, authorizor, storage, req)
+            events::post(&config, authorizor, storage, fastly_authed, req)
         } else {
             let mut allow = "OPTIONS".to_string();
 
@@ -89,7 +90,7 @@ pub fn handle_request(
         }
     } else if path == "/admin/keys" && config.admin_enabled {
         if req.get_method() == "POST" {
-            admin::post_keys(req)
+            admin::post_keys(fastly_authed, req)
         } else {
             Response::from_status(StatusCode::METHOD_NOT_ALLOWED)
                 .with_header(header::ALLOW, "POST")


### PR DESCRIPTION
This enables SSE clients to establish durable subscriptions, by including query parameter `durable=true`. When durability is enabled, the any messages retained in KV Store are replayed upon establishment.

The IDs used in SSE events are a concatenation of the topics of interest and their last known retained versions, e.g.:

```
event: message
id: jtest:d06fe8f6d007c421-8,jtest2:a7b89db793b3da37-5
data: other msg 1

event: message
id: jtest:d06fe8f6d007c421-8,jtest2:a7b89db793b3da37-6
data: other msg 2
```

If a client reconnects and specifies a received event ID in the `Last-Event-ID` request header, the server can avoid replaying messages the client has already seen.

Messages are delivered by publishing `hint` actions to Fanout which trigger message fetching. This avoids the need to personalize the event IDs in published payloads. Later on, we can look at implementing such personalization to avoid fetching.