### PR TITLE
add ability to create and validate tokens with internal key

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ pub struct Config {
     pub mqtt_enabled: bool,
     pub admin_enabled: bool,
     pub publish_token: String,
+    pub internal_key: Vec<u8>,
 }
 
 impl Default for Config {
@@ -17,6 +18,7 @@ impl Default for Config {
             mqtt_enabled: true,
             admin_enabled: true,
             publish_token: String::new(),
+            internal_key: Vec::new(),
         }
     }
 }
@@ -98,6 +100,12 @@ impl Source for ConfigAndSecretStoreSource {
 
                     config.publish_token = v;
                 }
+                Ok(None) => {}
+                Err(_) => return Err(ConfigError::StoreError),
+            }
+
+            match store.try_get("internal-key") {
+                Ok(Some(v)) => config.internal_key = v.plaintext().to_vec(),
                 Ok(None) => {}
                 Err(_) => return Err(ConfigError::StoreError),
             }

--- a/src/events.rs
+++ b/src/events.rs
@@ -88,7 +88,7 @@ pub fn get(authorizor: &dyn Authorizor, req: Request) -> Response {
             );
         };
 
-        match authorizor.validate_token(token) {
+        match authorizor.validate_token(token, None) {
             Ok(caps) => caps,
             Err(AuthorizationError::Token(_)) => {
                 return sse_error("forbidden", "Invalid token");
@@ -175,7 +175,7 @@ pub fn post(
             return text_response(StatusCode::BAD_REQUEST, "Missing 'Authorization' header");
         };
 
-        match authorizor.validate_token(token) {
+        match authorizor.validate_token(token, None) {
             Ok(caps) => caps,
             Err(AuthorizationError::Token(_)) => {
                 return text_response(StatusCode::FORBIDDEN, "Invalid token");

--- a/src/mqtthandler.rs
+++ b/src/mqtthandler.rs
@@ -141,7 +141,7 @@ fn handle_subscribe<'a>(ctx: &mut Context, p: Subscribe<'a>) -> Vec<Packet<'a>> 
     let mut allowed = false;
 
     if let Some(s) = &ctx.state.token {
-        if let Ok(caps) = ctx.authorizor.validate_token(s) {
+        if let Ok(caps) = ctx.authorizor.validate_token(s, None) {
             if caps.can_subscribe(p.topic) {
                 allowed = true;
             }
@@ -241,7 +241,7 @@ fn handle_publish<'a>(ctx: &mut Context, p: Publish<'a>) -> Vec<Packet<'a>> {
     let mut allowed = false;
 
     if let Some(s) = &ctx.state.token {
-        if let Ok(caps) = ctx.authorizor.validate_token(s) {
+        if let Ok(caps) = ctx.authorizor.validate_token(s, None) {
             if caps.can_publish(p.topic.as_ref()) {
                 allowed = true;
             }


### PR DESCRIPTION
In order to support Fanout's reliability mode, we'll need to be able to handle fetches from Fanout and these fetches will need to be authenticated. We'll plan for the fetches to use JWTs, signed with a special internal app key. This PR adds the ability to create JWTs (up until now we only ever had a way to validate them) and adds a key in Secret Store to be used for creating and validating tokens used by Fanout fetches. We don't actually use these new abilities anywhere yet, but we will when we start using Fanout's reliability mode.

Note: for WebSocket-over-HTTP fetches, we're currently relying on the client-supplied JWT to authenticate the fetches. We can potentially do the same for the reliability mode, but being able to sign our own JWTs gives us flexibility around how we handle internal auth, especially when the client authenticates with a Fastly API Token instead of a JWT.