### PR TITLE
check Grip-Sig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
  "serde_urlencoded",
  "sha2 0.9.9",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "url",
 ]
@@ -674,7 +674,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spki 0.6.0",
- "thiserror",
+ "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -927,6 +927,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
+ "thiserror 2.0.12",
  "time",
 ]
 
@@ -1237,7 +1238,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1245,6 +1255,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rand = "0.9"
 serde = "1"
 serde_json = "1"
 sha1 = "0.10"
+thiserror = "2"
 time = "0.3"
 
 [lints.rust]

--- a/src/grip.rs
+++ b/src/grip.rs
@@ -1,0 +1,68 @@
+use jwt_simple::prelude::*;
+use std::env;
+use thiserror::Error;
+
+const FASTLY_PUBLIC_KEY: &str = concat!(
+    "-----BEGIN PUBLIC KEY-----\n",
+    "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECKo5A1ebyFcnmVV8SE5On+8G81Jy\n",
+    "BjSvcrx4VLetWCjuDAmppTo3xM/zz763COTCgHfp/6lPdCyYjjqc+GM7sw==\n",
+    "-----END PUBLIC KEY-----\n"
+);
+
+#[derive(Debug, Error)]
+pub enum ValidationError {
+    #[error("token verification failed: {0}")]
+    Verify(#[from] jwt_simple::Error),
+
+    #[error("token has no issuer")]
+    NoIssuer,
+
+    #[error("token was issued for a different service ID: {0}")]
+    ServiceMismatch(String),
+}
+
+pub fn validate_grip_sig(sig: &str) -> Result<(), ValidationError> {
+    let key = ES256PublicKey::from_pem(FASTLY_PUBLIC_KEY).expect("public key should be parsable");
+
+    let service_id = env::var("FASTLY_SERVICE_ID").expect("FASTLY_SERVICE_ID should be set");
+
+    let claims = key.verify_token::<NoCustomClaims>(sig, None)?;
+
+    let Some(issuer) = claims.issuer else {
+        return Err(ValidationError::NoIssuer);
+    };
+
+    if issuer != format!("fastly:{service_id}") {
+        return Err(ValidationError::ServiceMismatch(issuer));
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Default, PartialEq, serde::Serialize)]
+pub struct ControlMessage {
+    #[serde(rename(serialize = "type"))]
+    pub ctype: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel: Option<String>,
+
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub filters: Vec<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_fastly_key() {
+        ES256PublicKey::from_pem(FASTLY_PUBLIC_KEY).unwrap();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod admin;
 pub mod auth;
 pub mod config;
 pub mod events;
+pub mod grip;
 pub mod mqtthandler;
 pub mod mqttpacket;
 pub mod mqtttransport;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,11 +13,11 @@ fn main() -> Result<(), Error> {
     if local {
         let config_source = config::TestSource;
 
-        routes::handle_request(&config_source, &authorizor, &storage, req)?;
+        routes::handle_request(&config_source, &authorizor, &storage, false, req)?;
     } else {
         let config_source = config::ConfigAndSecretStoreSource::new("config", "secrets");
 
-        routes::handle_request(&config_source, &authorizor, &storage, req)?;
+        routes::handle_request(&config_source, &authorizor, &storage, true, req)?;
     }
 
     Ok(())

--- a/src/mqtttransport.rs
+++ b/src/mqtttransport.rs
@@ -1,9 +1,10 @@
 use crate::auth::Authorizor;
 use crate::config::Config;
+use crate::grip::ControlMessage;
 use crate::mqtthandler;
 use crate::mqttpacket::Packet;
 use crate::storage::Storage;
-use crate::websocket::{parse_websocket_event, ControlMessage, WsEvent};
+use crate::websocket::{parse_websocket_event, WsEvent};
 use fastly::http::{HeaderValue, StatusCode};
 use fastly::{Body, Request, Response};
 use std::collections::HashSet;

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -6,24 +6,6 @@ pub struct WsEvent {
     pub content: Vec<u8>,
 }
 
-#[derive(Debug, Default, PartialEq, serde::Serialize)]
-pub struct ControlMessage {
-    #[serde(rename(serialize = "type"))]
-    pub ctype: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub channel: Option<String>,
-
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub filters: Vec<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub value: Option<String>,
-}
-
 fn find_byte(haystack: &[u8], needle: u8) -> Option<usize> {
     for (index, b) in haystack.iter().enumerate() {
         if *b == needle {


### PR DESCRIPTION
This creates a `grip` module with the ability to validate Fanout `Grip-Sig` request headers, and such validation is performed on all routes that rely on Fanout. Also, GRIP-related code in the `websocket` module is moved to over.