### PR TITLE
ensure store not found is treated the same as item not found

### DIFF
--- a/src/mqtthandler.rs
+++ b/src/mqtthandler.rs
@@ -361,7 +361,7 @@ pub fn handle_sync(ctx: &mut Context) -> Vec<Packet<'static>> {
 
         let r = match ctx.storage.read_retained(topic, after) {
             Ok(Some(r)) => r,
-            Ok(None) => continue,
+            Ok(None) | Err(StorageError::StoreNotFound) => continue,
             Err(e) => {
                 println!("failed to read message from storage: {e:?}");
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -101,7 +101,9 @@ impl Storage for KVStoreStorage {
     ) -> Result<RetainedVersion, StorageError> {
         let store = match KVStore::open(&self.store_name) {
             Ok(Some(store)) => store,
-            Ok(None) => return Err(StorageError::StoreNotFound),
+            Ok(None) | Err(KVStoreError::StoreNotFound(_)) => {
+                return Err(StorageError::StoreNotFound)
+            }
             Err(e) => return Err(StorageError::KVStore(e)),
         };
 
@@ -175,7 +177,9 @@ impl Storage for KVStoreStorage {
     ) -> Result<Option<RetainedSlot>, StorageError> {
         let store = match KVStore::open(&self.store_name) {
             Ok(Some(store)) => store,
-            Ok(None) => return Err(StorageError::StoreNotFound),
+            Ok(None) | Err(KVStoreError::StoreNotFound(_)) => {
+                return Err(StorageError::StoreNotFound)
+            }
             Err(e) => return Err(StorageError::KVStore(e)),
         };
 


### PR DESCRIPTION
Apparently `KVStore::open` can return `Err` when a store is not found, even though the documentation says `Ok(None)` will be returned.